### PR TITLE
Implement basic CRUD Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ONTOLOGY POC
 
-This proof of concept implements basic CRUD APIs for an ontology-based forwarding solution using Flask and SQLAlchemy.
+This sample Flask web app uses Python's built‑in `sqlite3` module to store data.
+The schema follows the ontology tables and is created automatically on startup.
+Only simple `GET` endpoints are provided to list rows from each table.
 
 ## Setup
 
@@ -20,11 +22,11 @@ The application uses SQLite (`poc.db`) in the project directory.
 
 ## Available endpoints
 
-- `/carriers`
-- `/locations`
-- `/routes`
-- `/schedules`
-- `/shipments`
-- `/costitems`
+- `GET /carriers`
+- `GET /locations`
+- `GET /routes`
+- `GET /schedules`
+- `GET /shipments`
+- `GET /costitems`
+- `GET /locationcoverage`
 
-Each endpoint supports standard `POST`, `GET`, `PUT`, and `DELETE` operations.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-#test
+# ONTOLOGY POC
+
+This proof of concept implements basic CRUD APIs for an ontology-based forwarding solution using Flask and SQLAlchemy.
+
+## Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the application
+
+```bash
+python app.py
+```
+
+The application uses SQLite (`poc.db`) in the project directory.
+
+## Available endpoints
+
+- `/carriers`
+- `/locations`
+- `/routes`
+- `/schedules`
+- `/shipments`
+- `/costitems`
+
+Each endpoint supports standard `POST`, `GET`, `PUT`, and `DELETE` operations.

--- a/app.py
+++ b/app.py
@@ -1,163 +1,144 @@
-from flask import Flask, request, jsonify
-from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import Column, Integer, Float, String, Boolean, ForeignKey, DateTime
-from sqlalchemy.orm import relationship
+from flask import Flask, g, jsonify
+import sqlite3
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///poc.db'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+DATABASE = 'poc.db'
 
+SCHEMA = '''
+CREATE TABLE IF NOT EXISTS Carrier (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    carrier_name TEXT,
+    type TEXT,
+    reliability REAL,
+    supports_freezing BOOLEAN,
+    supports_dangerous_goods BOOLEAN
+);
 
-db = SQLAlchemy(app)
+CREATE TABLE IF NOT EXISTS Location (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    type TEXT,
+    country TEXT,
+    supports_freezing BOOLEAN,
+    supports_storage BOOLEAN,
+    supports_dangerous_goods BOOLEAN
+);
 
+CREATE TABLE IF NOT EXISTS Route (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    origin_id INTEGER,
+    destination_id INTEGER,
+    carrier_id INTEGER,
+    base_cost REAL,
+    lead_time REAL,
+    transport_mode TEXT,
+    type TEXT,
+    supports_freezing BOOLEAN,
+    supports_dangerous_goods BOOLEAN,
+    FOREIGN KEY (origin_id) REFERENCES Location(id),
+    FOREIGN KEY (destination_id) REFERENCES Location(id),
+    FOREIGN KEY (carrier_id) REFERENCES Carrier(id)
+);
 
-# Association table for coversLocation relationship
-covers_location = db.Table(
-    'covers_location',
-    db.Column('location_id', db.Integer, db.ForeignKey('location.id'), primary_key=True),
-    db.Column('covered_location_id', db.Integer, db.ForeignKey('location.id'), primary_key=True)
-)
+CREATE TABLE IF NOT EXISTS Schedule (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    route_id INTEGER,
+    departure_day TEXT,
+    cutoff_day_offset INTEGER,
+    cutoff_hour INTEGER,
+    frequency INTEGER,
+    type TEXT,
+    FOREIGN KEY (route_id) REFERENCES Route(id)
+);
 
+CREATE TABLE IF NOT EXISTS Shipment (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    origin_id INTEGER,
+    destination_id INTEGER,
+    weight REAL,
+    deadline DATETIME,
+    requires_freezing BOOLEAN,
+    is_dangerous BOOLEAN,
+    incoterms TEXT,
+    type TEXT,
+    FOREIGN KEY (origin_id) REFERENCES Location(id),
+    FOREIGN KEY (destination_id) REFERENCES Location(id)
+);
 
-class Carrier(db.Model):
-    id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    reliability = Column(Float)
-    type = Column(String)
-    supports_dangerous_goods = Column(Boolean, default=False)
-    supports_freezing = Column(Boolean, default=False)
-    routes = relationship('Route', back_populates='carrier')
+CREATE TABLE IF NOT EXISTS CostItem (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    applies_to TEXT,
+    applies_to_id INTEGER,
+    cost_type TEXT,
+    amount REAL,
+    trigger_type TEXT,
+    trigger_operator TEXT,
+    trigger_value REAL,
+    type TEXT
+);
 
+CREATE TABLE IF NOT EXISTS LocationCoverage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    warehouse_id INTEGER,
+    covers_location_id INTEGER,
+    FOREIGN KEY (warehouse_id) REFERENCES Location(id),
+    FOREIGN KEY (covers_location_id) REFERENCES Location(id)
+);
+'''
 
-class Location(db.Model):
-    id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    type = Column(String)
-    located_in_country = Column(String)
-    supports_freezing = Column(Boolean, default=False)
-    supports_storage = Column(Boolean, default=False)
-    supports_dangerous_goods = Column(Boolean, default=False)
-    covered_locations = relationship(
-        'Location',
-        secondary=covers_location,
-        primaryjoin=id == covers_location.c.location_id,
-        secondaryjoin=id == covers_location.c.covered_location_id,
-        backref='covering_locations'
-    )
+def get_db():
+    db = getattr(g, '_database', None)
+    if db is None:
+        db = g._database = sqlite3.connect(DATABASE)
+        db.row_factory = sqlite3.Row
+    return db
 
+@app.teardown_appcontext
+def close_connection(exception):
+    db = getattr(g, '_database', None)
+    if db is not None:
+        db.close()
 
-class Route(db.Model):
-    id = Column(Integer, primary_key=True)
-    origin_id = Column(Integer, ForeignKey('location.id'))
-    destination_id = Column(Integer, ForeignKey('location.id'))
-    carrier_id = Column(Integer, ForeignKey('carrier.id'))
-    base_cost = Column(Float)
-    lead_time = Column(Float)
-    transport_mode = Column(String)
-    supports_dangerous_goods = Column(Boolean, default=False)
-    supports_freezing = Column(Boolean, default=False)
-    type = Column(String)
+def init_db():
+    db = get_db()
+    db.executescript(SCHEMA)
+    db.commit()
 
-    origin = relationship('Location', foreign_keys=[origin_id])
-    destination = relationship('Location', foreign_keys=[destination_id])
-    carrier = relationship('Carrier', back_populates='routes')
-    schedules = relationship('Schedule', back_populates='route')
-    cost_items = relationship('CostItem', back_populates='route')
+def query_all(table):
+    cur = get_db().execute(f'SELECT * FROM {table}')
+    rows = cur.fetchall()
+    cur.close()
+    return [dict(row) for row in rows]
 
+@app.route('/carriers')
+def get_carriers():
+    return jsonify(query_all('Carrier'))
 
-class Schedule(db.Model):
-    id = Column(Integer, primary_key=True)
-    route_id = Column(Integer, ForeignKey('route.id'))
-    departure_day = Column(String)
-    frequency = Column(Integer)
-    cutoff_day_offset = Column(Integer)
-    cutoff_hour = Column(Integer)
-    type = Column(String)
+@app.route('/locations')
+def get_locations():
+    return jsonify(query_all('Location'))
 
-    route = relationship('Route', back_populates='schedules')
+@app.route('/routes')
+def get_routes():
+    return jsonify(query_all('Route'))
 
+@app.route('/schedules')
+def get_schedules():
+    return jsonify(query_all('Schedule'))
 
-class Shipment(db.Model):
-    id = Column(Integer, primary_key=True)
-    origin_id = Column(Integer, ForeignKey('location.id'))
-    destination_id = Column(Integer, ForeignKey('location.id'))
-    weight = Column(Float)
-    is_dangerous = Column(Boolean, default=False)
-    requires_freezing = Column(Boolean, default=False)
-    deadline = Column(DateTime)
-    incoterms = Column(String)
-    type = Column(String)
+@app.route('/shipments')
+def get_shipments():
+    return jsonify(query_all('Shipment'))
 
-    origin = relationship('Location', foreign_keys=[origin_id])
-    destination = relationship('Location', foreign_keys=[destination_id])
+@app.route('/costitems')
+def get_costitems():
+    return jsonify(query_all('CostItem'))
 
-
-class CostItem(db.Model):
-    id = Column(Integer, primary_key=True)
-    route_id = Column(Integer, ForeignKey('route.id'))
-    cost_type = Column(String)
-    amount = Column(Float)
-    trigger_type = Column(String)
-    trigger_operator = Column(String)
-    trigger_value = Column(Float)
-    type = Column(String)
-
-    route = relationship('Route', back_populates='cost_items')
-
-
-# Utility functions
-
-def model_to_dict(obj):
-    return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
-
-
-def create_crud_endpoints(model, endpoint):
-    model_name = model.__name__.lower()
-
-    @app.route(f"/{endpoint}", methods=['POST'])
-    def create_item():
-        data = request.json or {}
-        item = model(**data)
-        db.session.add(item)
-        db.session.commit()
-        return jsonify(model_to_dict(item)), 201
-
-    @app.route(f"/{endpoint}", methods=['GET'])
-    def list_items():
-        items = model.query.all()
-        return jsonify([model_to_dict(i) for i in items])
-
-    @app.route(f"/{endpoint}/<int:item_id>", methods=['GET'])
-    def get_item(item_id):
-        item = model.query.get_or_404(item_id)
-        return jsonify(model_to_dict(item))
-
-    @app.route(f"/{endpoint}/<int:item_id>", methods=['PUT'])
-    def update_item(item_id):
-        item = model.query.get_or_404(item_id)
-        data = request.json or {}
-        for key, value in data.items():
-            setattr(item, key, value)
-        db.session.commit()
-        return jsonify(model_to_dict(item))
-
-    @app.route(f"/{endpoint}/<int:item_id>", methods=['DELETE'])
-    def delete_item(item_id):
-        item = model.query.get_or_404(item_id)
-        db.session.delete(item)
-        db.session.commit()
-        return '', 204
-
-
-create_crud_endpoints(Carrier, 'carriers')
-create_crud_endpoints(Location, 'locations')
-create_crud_endpoints(Route, 'routes')
-create_crud_endpoints(Schedule, 'schedules')
-create_crud_endpoints(Shipment, 'shipments')
-create_crud_endpoints(CostItem, 'costitems')
-
+@app.route('/locationcoverage')
+def get_location_coverage():
+    return jsonify(query_all('LocationCoverage'))
 
 if __name__ == '__main__':
     with app.app_context():
-        db.create_all()
+        init_db()
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,163 @@
+from flask import Flask, request, jsonify
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Column, Integer, Float, String, Boolean, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///poc.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+
+db = SQLAlchemy(app)
+
+
+# Association table for coversLocation relationship
+covers_location = db.Table(
+    'covers_location',
+    db.Column('location_id', db.Integer, db.ForeignKey('location.id'), primary_key=True),
+    db.Column('covered_location_id', db.Integer, db.ForeignKey('location.id'), primary_key=True)
+)
+
+
+class Carrier(db.Model):
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    reliability = Column(Float)
+    type = Column(String)
+    supports_dangerous_goods = Column(Boolean, default=False)
+    supports_freezing = Column(Boolean, default=False)
+    routes = relationship('Route', back_populates='carrier')
+
+
+class Location(db.Model):
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    type = Column(String)
+    located_in_country = Column(String)
+    supports_freezing = Column(Boolean, default=False)
+    supports_storage = Column(Boolean, default=False)
+    supports_dangerous_goods = Column(Boolean, default=False)
+    covered_locations = relationship(
+        'Location',
+        secondary=covers_location,
+        primaryjoin=id == covers_location.c.location_id,
+        secondaryjoin=id == covers_location.c.covered_location_id,
+        backref='covering_locations'
+    )
+
+
+class Route(db.Model):
+    id = Column(Integer, primary_key=True)
+    origin_id = Column(Integer, ForeignKey('location.id'))
+    destination_id = Column(Integer, ForeignKey('location.id'))
+    carrier_id = Column(Integer, ForeignKey('carrier.id'))
+    base_cost = Column(Float)
+    lead_time = Column(Float)
+    transport_mode = Column(String)
+    supports_dangerous_goods = Column(Boolean, default=False)
+    supports_freezing = Column(Boolean, default=False)
+    type = Column(String)
+
+    origin = relationship('Location', foreign_keys=[origin_id])
+    destination = relationship('Location', foreign_keys=[destination_id])
+    carrier = relationship('Carrier', back_populates='routes')
+    schedules = relationship('Schedule', back_populates='route')
+    cost_items = relationship('CostItem', back_populates='route')
+
+
+class Schedule(db.Model):
+    id = Column(Integer, primary_key=True)
+    route_id = Column(Integer, ForeignKey('route.id'))
+    departure_day = Column(String)
+    frequency = Column(Integer)
+    cutoff_day_offset = Column(Integer)
+    cutoff_hour = Column(Integer)
+    type = Column(String)
+
+    route = relationship('Route', back_populates='schedules')
+
+
+class Shipment(db.Model):
+    id = Column(Integer, primary_key=True)
+    origin_id = Column(Integer, ForeignKey('location.id'))
+    destination_id = Column(Integer, ForeignKey('location.id'))
+    weight = Column(Float)
+    is_dangerous = Column(Boolean, default=False)
+    requires_freezing = Column(Boolean, default=False)
+    deadline = Column(DateTime)
+    incoterms = Column(String)
+    type = Column(String)
+
+    origin = relationship('Location', foreign_keys=[origin_id])
+    destination = relationship('Location', foreign_keys=[destination_id])
+
+
+class CostItem(db.Model):
+    id = Column(Integer, primary_key=True)
+    route_id = Column(Integer, ForeignKey('route.id'))
+    cost_type = Column(String)
+    amount = Column(Float)
+    trigger_type = Column(String)
+    trigger_operator = Column(String)
+    trigger_value = Column(Float)
+    type = Column(String)
+
+    route = relationship('Route', back_populates='cost_items')
+
+
+# Utility functions
+
+def model_to_dict(obj):
+    return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+
+
+def create_crud_endpoints(model, endpoint):
+    model_name = model.__name__.lower()
+
+    @app.route(f"/{endpoint}", methods=['POST'])
+    def create_item():
+        data = request.json or {}
+        item = model(**data)
+        db.session.add(item)
+        db.session.commit()
+        return jsonify(model_to_dict(item)), 201
+
+    @app.route(f"/{endpoint}", methods=['GET'])
+    def list_items():
+        items = model.query.all()
+        return jsonify([model_to_dict(i) for i in items])
+
+    @app.route(f"/{endpoint}/<int:item_id>", methods=['GET'])
+    def get_item(item_id):
+        item = model.query.get_or_404(item_id)
+        return jsonify(model_to_dict(item))
+
+    @app.route(f"/{endpoint}/<int:item_id>", methods=['PUT'])
+    def update_item(item_id):
+        item = model.query.get_or_404(item_id)
+        data = request.json or {}
+        for key, value in data.items():
+            setattr(item, key, value)
+        db.session.commit()
+        return jsonify(model_to_dict(item))
+
+    @app.route(f"/{endpoint}/<int:item_id>", methods=['DELETE'])
+    def delete_item(item_id):
+        item = model.query.get_or_404(item_id)
+        db.session.delete(item)
+        db.session.commit()
+        return '', 204
+
+
+create_crud_endpoints(Carrier, 'carriers')
+create_crud_endpoints(Location, 'locations')
+create_crud_endpoints(Route, 'routes')
+create_crud_endpoints(Schedule, 'schedules')
+create_crud_endpoints(Shipment, 'shipments')
+create_crud_endpoints(CostItem, 'costitems')
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+flask_sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 Flask
-SQLAlchemy
-flask_sqlalchemy


### PR DESCRIPTION
## Summary
- add Flask/SQLAlchemy requirements
- implement `app.py` with ORM models and generic CRUD routes
- update README with setup and endpoint list

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846903ea25083289db37cc2c95aca95