### PR TITLE
Add CRUD UI for DB tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This sample Flask web app uses Python's built‑in `sqlite3` module to store data.
 The schema follows the ontology tables and is created automatically on startup.
-Only simple `GET` endpoints are provided to list rows from each table.
+웹 브라우저에서 기본 CRUD 화면을 제공하며,
+또한 각 테이블을 조회할 수 있는 간단한 `GET` API도 제공합니다.
 
 ## Setup
 
@@ -18,7 +19,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-The application uses SQLite (`poc.db`) in the project directory.
+애플리케이션은 `db/onai_route.db` 파일을 사용합니다.
 
 ## Available endpoints
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ title or 'DB Admin' }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; display: flex; }
+        nav { width: 200px; background: #f2f2f2; padding: 1em; }
+        main { flex: 1; padding: 1em; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 4px 8px; }
+        form.inline { display: inline; }
+    </style>
+</head>
+<body>
+<nav>
+    <ul>
+        <li><a href="{{ url_for('list_locations') }}">Locations</a></li>
+        <li><a href="{{ url_for('list_routes') }}">Routes</a></li>
+        <li><a href="{{ url_for('list_carriers') }}">Carriers</a></li>
+        <li><a href="{{ url_for('list_schedules') }}">Schedules</a></li>
+    </ul>
+</nav>
+<main>
+{% block content %}{% endblock %}
+</main>
+</body>
+</html>

--- a/templates/carrier_form.html
+++ b/templates/carrier_form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if carrier else 'New' }} Carrier</h1>
+<form method="post">
+    Name <input type="text" name="carrier_name" value="{{ carrier.carrier_name if carrier else '' }}"><br>
+    Type <input type="text" name="type" value="{{ carrier.type if carrier else '' }}"><br>
+    Reliability <input type="number" step="0.01" name="reliability" value="{{ carrier.reliability if carrier else '' }}"><br>
+    Supports Freezing <input type="checkbox" name="supports_freezing" value="1" {% if carrier and carrier.supports_freezing %}checked{% endif %}><br>
+    Supports Dangerous Goods <input type="checkbox" name="supports_dangerous_goods" value="1" {% if carrier and carrier.supports_dangerous_goods %}checked{% endif %}><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/carriers.html
+++ b/templates/carriers.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Carriers</h1>
+<form method="get">
+    Name <input type="text" name="carrier_name" value="{{ request.args.get('carrier_name','') }}">
+    Type <input type="text" name="type" value="{{ request.args.get('type','') }}">
+    <input type="submit" value="Search">
+    <a href="{{ url_for('new_carrier') }}">Create</a>
+</form>
+<table>
+<tr>
+    <th>ID</th>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Reliability</th>
+    <th>Freezing</th>
+    <th>Dangerous Goods</th>
+    <th>Actions</th>
+</tr>
+{% for c in rows %}
+<tr>
+    <td>{{ c['id'] }}</td>
+    <td>{{ c['carrier_name'] }}</td>
+    <td>{{ c['type'] }}</td>
+    <td>{{ c['reliability'] }}</td>
+    <td>{{ c['supports_freezing'] }}</td>
+    <td>{{ c['supports_dangerous_goods'] }}</td>
+    <td>
+        <a href="{{ url_for('edit_carrier', id=c['id']) }}">Edit</a>
+        <form class="inline" method="post" action="{{ url_for('delete_carrier', id=c['id']) }}">
+            <button type="submit">Delete</button>
+        </form>
+    </td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/location_form.html
+++ b/templates/location_form.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if location else 'New' }} Location</h1>
+<form method="post">
+    Name <input type="text" name="name" value="{{ location.name if location else '' }}"><br>
+    Type <input type="text" name="type" value="{{ location.type if location else '' }}"><br>
+    Country <input type="text" name="country" value="{{ location.country if location else '' }}"><br>
+    Supports Freezing <input type="checkbox" name="supports_freezing" value="1" {% if location and location.supports_freezing %}checked{% endif %}><br>
+    Supports Storage <input type="checkbox" name="supports_storage" value="1" {% if location and location.supports_storage %}checked{% endif %}><br>
+    Supports Dangerous Goods <input type="checkbox" name="supports_dangerous_goods" value="1" {% if location and location.supports_dangerous_goods %}checked{% endif %}><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Locations</h1>
+<form method="get">
+    Name <input type="text" name="name" value="{{ request.args.get('name','') }}">
+    Type <input type="text" name="type" value="{{ request.args.get('type','') }}">
+    Country <input type="text" name="country" value="{{ request.args.get('country','') }}">
+    <input type="submit" value="Search">
+    <a href="{{ url_for('new_location') }}">Create</a>
+</form>
+<table>
+<tr>
+    <th>ID</th><th>Name</th><th>Type</th><th>Country</th><th>Freezing</th><th>Storage</th><th>Dangerous</th><th>Actions</th>
+</tr>
+{% for l in rows %}
+<tr>
+    <td>{{ l['id'] }}</td>
+    <td>{{ l['name'] }}</td>
+    <td>{{ l['type'] }}</td>
+    <td>{{ l['country'] }}</td>
+    <td>{{ l['supports_freezing'] }}</td>
+    <td>{{ l['supports_storage'] }}</td>
+    <td>{{ l['supports_dangerous_goods'] }}</td>
+    <td>
+        <a href="{{ url_for('edit_location', id=l['id']) }}">Edit</a>
+        <form class="inline" method="post" action="{{ url_for('delete_location', id=l['id']) }}">
+            <button type="submit">Delete</button>
+        </form>
+    </td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/route_form.html
+++ b/templates/route_form.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if route else 'New' }} Route</h1>
+<form method="post">
+    Origin
+    <select name="origin_id">
+        {% for l in locations %}
+            <option value="{{ l['id'] }}" {% if route and route.origin_id==l['id'] %}selected{% endif %}>{{ l['name'] }}</option>
+        {% endfor %}
+    </select><br>
+    Destination
+    <select name="destination_id">
+        {% for l in locations %}
+            <option value="{{ l['id'] }}" {% if route and route.destination_id==l['id'] %}selected{% endif %}>{{ l['name'] }}</option>
+        {% endfor %}
+    </select><br>
+    Carrier
+    <select name="carrier_id">
+        {% for c in carriers %}
+            <option value="{{ c['id'] }}" {% if route and route.carrier_id==c['id'] %}selected{% endif %}>{{ c['carrier_name'] }}</option>
+        {% endfor %}
+    </select><br>
+    Base Cost <input type="number" step="0.01" name="base_cost" value="{{ route.base_cost if route else '' }}"><br>
+    Lead Time <input type="number" step="0.01" name="lead_time" value="{{ route.lead_time if route else '' }}"><br>
+    Transport Mode <input type="text" name="transport_mode" value="{{ route.transport_mode if route else '' }}"><br>
+    Type <input type="text" name="type" value="{{ route.type if route else '' }}"><br>
+    Supports Freezing <input type="checkbox" name="supports_freezing" value="1" {% if route and route.supports_freezing %}checked{% endif %}><br>
+    Supports Dangerous Goods <input type="checkbox" name="supports_dangerous_goods" value="1" {% if route and route.supports_dangerous_goods %}checked{% endif %}><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/routes.html
+++ b/templates/routes.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Routes</h1>
+<form method="get">
+    Origin <input type="text" name="origin" value="{{ request.args.get('origin','') }}">
+    Destination <input type="text" name="destination" value="{{ request.args.get('destination','') }}">
+    <input type="submit" value="Search">
+    <a href="{{ url_for('new_route') }}">Create</a>
+</form>
+<table>
+<tr>
+    <th>ID</th><th>Origin</th><th>Destination</th><th>Carrier</th><th>Cost</th><th>Lead Time</th><th>Mode</th><th>Type</th><th>Freezing</th><th>Dangerous</th><th>Actions</th>
+</tr>
+{% for r in rows %}
+<tr>
+    <td>{{ r['id'] }}</td>
+    <td>{{ r['origin_name'] }}</td>
+    <td>{{ r['destination_name'] }}</td>
+    <td>{{ r['carrier_name'] }}</td>
+    <td>{{ r['base_cost'] }}</td>
+    <td>{{ r['lead_time'] }}</td>
+    <td>{{ r['transport_mode'] }}</td>
+    <td>{{ r['type'] }}</td>
+    <td>{{ r['supports_freezing'] }}</td>
+    <td>{{ r['supports_dangerous_goods'] }}</td>
+    <td>
+        <a href="{{ url_for('edit_route', id=r['id']) }}">Edit</a>
+        <form class="inline" method="post" action="{{ url_for('delete_route', id=r['id']) }}">
+            <button type="submit">Delete</button>
+        </form>
+    </td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/schedule_form.html
+++ b/templates/schedule_form.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if schedule else 'New' }} Schedule</h1>
+<form method="post">
+    Route
+    <select name="route_id">
+        {% for r in routes %}
+            <option value="{{ r['id'] }}" {% if schedule and schedule.route_id==r['id'] %}selected{% endif %}>{{ r['origin_name'] }} - {{ r['destination_name'] }}</option>
+        {% endfor %}
+    </select><br>
+    Departure Day <input type="text" name="departure_day" value="{{ schedule.departure_day if schedule else '' }}"><br>
+    Cutoff Day Offset <input type="number" name="cutoff_day_offset" value="{{ schedule.cutoff_day_offset if schedule else '' }}"><br>
+    Cutoff Hour <input type="number" name="cutoff_hour" value="{{ schedule.cutoff_hour if schedule else '' }}"><br>
+    Frequency <input type="number" name="frequency" value="{{ schedule.frequency if schedule else '' }}"><br>
+    Type <input type="text" name="type" value="{{ schedule.type if schedule else '' }}"><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/schedules.html
+++ b/templates/schedules.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Schedules</h1>
+<form method="get">
+    Route
+    <select name="route_id">
+        <option value="">-- All --</option>
+        {% for r in routes %}
+            <option value="{{ r['id'] }}" {% if request.args.get('route_id') == str(r['id']) %}selected{% endif %}>{{ r['origin_name'] }} - {{ r['destination_name'] }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Search">
+    <a href="{{ url_for('new_schedule') }}">Create</a>
+</form>
+<table>
+<tr>
+    <th>ID</th><th>Route</th><th>Departure Day</th><th>Cutoff Day Offset</th><th>Cutoff Hour</th><th>Frequency</th><th>Type</th><th>Actions</th>
+</tr>
+{% for s in rows %}
+<tr>
+    <td>{{ s['id'] }}</td>
+    <td>{{ s['origin_name'] }} - {{ s['destination_name'] }}</td>
+    <td>{{ s['departure_day'] }}</td>
+    <td>{{ s['cutoff_day_offset'] }}</td>
+    <td>{{ s['cutoff_hour'] }}</td>
+    <td>{{ s['frequency'] }}</td>
+    <td>{{ s['type'] }}</td>
+    <td>
+        <a href="{{ url_for('edit_schedule', id=s['id']) }}">Edit</a>
+        <form class="inline" method="post" action="{{ url_for('delete_schedule', id=s['id']) }}">
+            <button type="submit">Delete</button>
+        </form>
+    </td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- connect Flask app to existing `onai_route.db`
- add helper database functions and full CRUD web routes
- add HTML templates for Locations, Carriers, Routes, and Schedules
- update README to mention CRUD UI and database path

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6847e76420fc8328b9e2916a7943da8b