### PR TITLE
Add route and tariff search improvements

### DIFF
--- a/templates/plan.html
+++ b/templates/plan.html
@@ -29,7 +29,7 @@
         <h3>Plan {{ loop.index }} - Routes: {{ plan.routes|length }}, Recommended Start: {{ plan.recommended_start }}, Cost Sum: {{ plan.total_cost }}, Lead Time Sum: {{ plan.total_lead_time }}</h3>
         <table>
             <tr>
-                <th>#</th><th>ID</th><th>Origin</th><th>Destination</th><th>Cost</th><th>Lead Time</th>
+                <th>#</th><th>ID</th><th>Origin</th><th>Destination</th><th>Tariff ID</th><th>Cost</th><th>Lead Time</th>
             </tr>
             {% for r in plan.routes %}
             <tr>
@@ -37,6 +37,7 @@
                 <td>{{ r['id'] }}</td>
                 <td>{{ r['origin_name'] }}</td>
                 <td>{{ r['destination_name'] }}</td>
+                <td>{{ r['tariff_id'] }}</td>
                 <td>{{ r['tariff_cost'] }}</td>
                 <td>{{ r['lead_time'] }}</td>
             </tr>

--- a/templates/tariffs.html
+++ b/templates/tariffs.html
@@ -2,11 +2,12 @@
 {% block content %}
 <h1>Tariff</h1>
 <form method="get">
+    Route ID <input type="number" name="route_id" value="{{ request.args.get('route_id','') }}">
     Route
-    <select name="route_id">
+    <select name="route_select">
         <option value="">-- All --</option>
         {% for r in routes %}
-            <option value="{{ r['id'] }}" {% if request.args.get('route_id') == r['id']|string %}selected{% endif %}>{{ r['origin_name'] }} - {{ r['destination_name'] }}</option>
+            <option value="{{ r['id'] }}" {% if request.args.get('route_select') == r['id']|string %}selected{% endif %}>{{ r['origin_name'] }} - {{ r['destination_name'] }}</option>
         {% endfor %}
     </select>
     Valid From <input type="date" name="valid_from" value="{{ request.args.get('valid_from','') }}">


### PR DESCRIPTION
## Summary
- filter tariffs by route ID using new search box
- display tariff ID for each route on plan results
- annotate recommended routes with tariff info

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684927de79748328941aa25cfa4383e7