### PR TITLE
Improve plan view

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,12 +207,13 @@ def recommend_plans(origin_id, dest_id, start_date, end_date):
                 best_costs = costs
                 best_ids = ids
             date += timedelta(days=1)
-        plan['total_cost'] = best_cost
+        plan['total_cost'] = round(best_cost, 2) if best_cost is not None else None
         plan['recommended_start'] = best_date.strftime('%Y-%m-%d') if best_date else None
         if best_costs:
             for r, c, tid in zip(plan['routes'], best_costs, best_ids):
-                r['tariff_cost'] = c
+                r['tariff_cost'] = round(c, 2)
                 r['tariff_id'] = tid
+    plans.sort(key=lambda p: (p['total_cost'] if p['total_cost'] is not None else float('inf')))
     return plans
 
 
@@ -494,6 +495,12 @@ def get_location_coverage():
 @app.route('/tariffs')
 def get_tariffs():
     return jsonify(query_all('Tariff'))
+
+
+@app.route('/tariff/<int:id>')
+def get_tariff(id):
+    row = query_db("SELECT * FROM Tariff WHERE id=?", [id], one=True)
+    return jsonify(dict(row) if row else {})
 
 if __name__ == '__main__':
     with app.app_context():

--- a/templates/plan.html
+++ b/templates/plan.html
@@ -29,7 +29,7 @@
         <h3>Plan {{ loop.index }} - Routes: {{ plan.routes|length }}, Recommended Start: {{ plan.recommended_start }}, Cost Sum: {{ plan.total_cost }}, Lead Time Sum: {{ plan.total_lead_time }}</h3>
         <table>
             <tr>
-                <th>#</th><th>ID</th><th>Origin</th><th>Destination</th><th>Tariff ID</th><th>Cost</th><th>Lead Time</th>
+                <th>#</th><th>Route ID</th><th>Origin</th><th>Destination</th><th>Tariff ID</th><th>Cost</th><th>Lead Time</th>
             </tr>
             {% for r in plan.routes %}
             <tr>
@@ -37,7 +37,7 @@
                 <td>{{ r['id'] }}</td>
                 <td>{{ r['origin_name'] }}</td>
                 <td>{{ r['destination_name'] }}</td>
-                <td>{{ r['tariff_id'] }}</td>
+                <td><span class="tariff" data-id="{{ r['tariff_id'] }}">{{ r['tariff_id'] }}</span></td>
                 <td>{{ r['tariff_cost'] }}</td>
                 <td>{{ r['lead_time'] }}</td>
             </tr>
@@ -45,6 +45,7 @@
         </table>
     {% endfor %}
 {% endif %}
+<div id="tariff-tooltip" style="position:absolute;display:none;border:1px solid #ccc;background:#fff;padding:4px;font-size:0.9em;"></div>
 <script>
 const locations = {{ locations|tojson }};
 function populate(typeId, nameId, selected){
@@ -66,6 +67,27 @@ window.addEventListener('load', () => {
     populate('dest_type','dest_id','{{ dest_id }}');
     document.getElementById('origin_type').addEventListener('change', () => populate('origin_type','origin_id'));
     document.getElementById('dest_type').addEventListener('change', () => populate('dest_type','dest_id'));
+
+    const tooltip = document.getElementById('tariff-tooltip');
+    document.querySelectorAll('.tariff').forEach(el => {
+        el.addEventListener('mouseenter', async (e) => {
+            const id = el.dataset.id;
+            if(!id){ return; }
+            const res = await fetch(`/tariff/${id}`);
+            if(res.ok){
+                const data = await res.json();
+                tooltip.innerHTML = `Cost: ${data.cost}<br>Valid: ${data.valid_from} - ${data.valid_to}`;
+                tooltip.style.display = 'block';
+            }
+        });
+        el.addEventListener('mousemove', (e) => {
+            tooltip.style.left = e.pageX + 'px';
+            tooltip.style.top = e.pageY + 'px';
+        });
+        el.addEventListener('mouseleave', () => {
+            tooltip.style.display = 'none';
+        });
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- round cost calculations and sort plans by cheapest first
- expose `/tariff/<id>` API endpoint
- show tariff info tooltip when hovering over tariff ID in plan table
- clarify column header to `Route ID`

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: not run due to manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_68492c746e788328afe25e284e5a1682