### PR TITLE
Add transport policy management

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from views import (
     tariffs_bp,
     plan_bp,
     api_bp,
+    policies_bp,
 )
 
 app = Flask(__name__)
@@ -27,6 +28,7 @@ app.register_blueprint(schedules_bp)
 app.register_blueprint(tariffs_bp)
 app.register_blueprint(plan_bp)
 app.register_blueprint(api_bp)
+app.register_blueprint(policies_bp)
 
 if __name__ == '__main__':
     with app.app_context():

--- a/database.py
+++ b/database.py
@@ -92,6 +92,14 @@ CREATE TABLE IF NOT EXISTS Tariff (
     cost REAL,
     FOREIGN KEY (route_id) REFERENCES Route(id)
 );
+
+CREATE TABLE IF NOT EXISTS Policy (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    description TEXT,
+    conditions TEXT,
+    action TEXT,
+    active BOOLEAN
+);
 '''
 
 def get_db():

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
         <li><a href="{{ url_for('carriers.list_carriers') }}">Carriers</a></li>
         <li><a href="{{ url_for('schedules.list_schedules') }}">Schedules</a></li>
         <li><a href="{{ url_for('tariffs.list_tariffs') }}">Tariff</a></li>
+        <li><a href="{{ url_for('policies.list_policies') }}">Policies</a></li>
         <li><a href="{{ url_for('plan.plan') }}">Plan</a></li>
     </ul>
 </nav>

--- a/templates/plan.html
+++ b/templates/plan.html
@@ -22,9 +22,15 @@
         <select name="dest_id" id="dest_id"></select>
         도착일 <input type="date" name="end_date" value="{{ end_date }}">
     </div>
+    <div>
+        Weight <input type="number" step="0.01" name="weight" value="{{ weight if weight is not none else '' }}">
+        Requires Freezing <input type="checkbox" name="requires_freezing" value="1" {% if requires_freezing %}checked{% endif %}>
+        Dangerous Goods <input type="checkbox" name="is_dangerous" value="1" {% if is_dangerous %}checked{% endif %}>
+    </div>
     <button type="submit">Plan 추천</button>
 </form>
 {% if plans %}
+    <p>Available routes after policy: {{ plans|length }}</p>
     {% for plan in plans %}
         <h3>Plan {{ loop.index }} - Routes: {{ plan.routes|length }}, Recommended Start: {{ plan.recommended_start }}, Cost Sum: {{ plan.total_cost }}, Lead Time Sum: {{ plan.total_lead_time }}</h3>
         <table>

--- a/templates/policies.html
+++ b/templates/policies.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Policies</h1>
+<a href="{{ url_for('policies.new_policy') }}">Create</a>
+<table>
+    <tr><th>ID</th><th>Description</th><th>Active</th><th>Actions</th></tr>
+    {% for p in rows %}
+    <tr>
+        <td>{{ p.id }}</td>
+        <td>{{ p.description }}</td>
+        <td>{{ 'Y' if p.active else 'N' }}</td>
+        <td>
+            <a href="{{ url_for('policies.edit_policy', id=p.id) }}">Edit</a>
+            <form class="inline" method="post" action="{{ url_for('policies.delete_policy', id=p.id) }}">
+                <button type="submit">Delete</button>
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/policy_form.html
+++ b/templates/policy_form.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if policy else 'New' }} Policy</h1>
+<form method="post" id="policy-form">
+    Description <input type="text" name="description" value="{{ policy.description if policy else '' }}"><br>
+    Active <input type="checkbox" name="active" value="1" {% if policy and policy.active %}checked{% endif %}><br>
+    <h3>Conditions</h3>
+    <table id="conds"></table>
+    <button type="button" onclick="addCond()">Add Condition</button>
+    <input type="hidden" name="conditions_json" id="conditions_json">
+    <h3>Action</h3>
+    Allow Route IDs <input type="text" id="allow_routes" value=""><br>
+    Block Route IDs <input type="text" id="block_routes" value=""><br>
+    Allow Modes <input type="text" id="allow_modes" value=""><br>
+    <input type="hidden" name="action_json" id="action_json">
+    <button type="submit">Save</button>
+</form>
+<script>
+const fields = ['requires_freezing','is_dangerous','weight'];
+function addCond(field='',op='=',value='',connector='AND'){
+    const table=document.getElementById('conds');
+    const row=document.createElement('tr');
+    row.innerHTML=`<td><select class="field">${fields.map(f=>`<option value="${f}" ${f==field?'selected':''}>${f}</option>`).join('')}</select></td>`+
+                  `<td><select class="op"><option>=</option><option>!=</option><option>></option><option><</option></select></td>`+
+                  `<td><input class="value" value="${value}"></td>`+
+                  `<td><select class="conn"><option value="AND" ${connector=='AND'?'selected':''}>AND</option><option value="OR" ${connector=='OR'?'selected':''}>OR</option></select></td>`;
+    row.querySelector('.op').value=op;
+    table.appendChild(row);
+}
+function gather(){
+    const conds=[];
+    document.querySelectorAll('#conds tr').forEach(tr=>{
+        conds.push({
+            field:tr.querySelector('.field').value,
+            op:tr.querySelector('.op').value,
+            value:tr.querySelector('.value').value,
+            connector:tr.querySelector('.conn').value
+        });
+    });
+    document.getElementById('conditions_json').value=JSON.stringify(conds);
+    const action={};
+    const allow=document.getElementById('allow_routes').value.trim();
+    if(allow) action.allow_route_ids=allow.split(',').map(s=>parseInt(s.trim())).filter(n=>!isNaN(n));
+    const block=document.getElementById('block_routes').value.trim();
+    if(block) action.block_route_ids=block.split(',').map(s=>parseInt(s.trim())).filter(n=>!isNaN(n));
+    const modes=document.getElementById('allow_modes').value.trim();
+    if(modes) action.allow_modes=modes.split(',').map(s=>s.trim()).filter(s=>s);
+    document.getElementById('action_json').value=JSON.stringify(action);
+}
+document.getElementById('policy-form').addEventListener('submit',gather);
+{% if policy %}
+const pc = {{ policy.conditions|tojson }};
+try{const conds=JSON.parse(pc);conds.forEach(c=>addCond(c.field,c.op,c.value,c.connector));}catch(e){}
+try{const ac=JSON.parse({{ policy.action|tojson }});if(ac.allow_route_ids)document.getElementById('allow_routes').value=ac.allow_route_ids.join(',');if(ac.block_route_ids)document.getElementById('block_routes').value=ac.block_route_ids.join(',');if(ac.allow_modes)document.getElementById('allow_modes').value=ac.allow_modes.join(',');}catch(e){}
+{% else %}
+addCond();
+{% endif %}
+</script>
+{% endblock %}

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -5,6 +5,7 @@ from .schedules import bp as schedules_bp
 from .tariffs import bp as tariffs_bp
 from .plan_view import bp as plan_bp
 from .api import bp as api_bp
+from .policies import bp as policies_bp
 
 __all__ = [
     'locations_bp',
@@ -14,4 +15,5 @@ __all__ = [
     'tariffs_bp',
     'plan_bp',
     'api_bp',
+    'policies_bp',
 ]

--- a/views/plan_view.py
+++ b/views/plan_view.py
@@ -10,6 +10,7 @@ def plan():
     locations = query_db("SELECT id, name, type FROM Location")
     types = sorted({l['type'] for l in locations})
     origin_type = dest_type = origin_id = dest_id = start_date = end_date = None
+    weight = requires_freezing = is_dangerous = None
     plans = None
     if request.method == 'POST':
         origin_type = request.form.get('origin_type')
@@ -18,7 +19,15 @@ def plan():
         dest_id = int(request.form.get('dest_id'))
         start_date = request.form.get('start_date')
         end_date = request.form.get('end_date')
-        plans = recommend_plans(origin_id, dest_id, start_date, end_date)
+        weight = float(request.form.get('weight') or 0)
+        requires_freezing = 1 if request.form.get('requires_freezing') else 0
+        is_dangerous = 1 if request.form.get('is_dangerous') else 0
+        shipment = {
+            'weight': weight,
+            'requires_freezing': requires_freezing,
+            'is_dangerous': is_dangerous,
+        }
+        plans = recommend_plans(origin_id, dest_id, start_date, end_date, shipment)
     return render_template(
         'plan.html',
         types=types,
@@ -29,5 +38,8 @@ def plan():
         dest_id=dest_id,
         start_date=start_date,
         end_date=end_date,
+        weight=weight,
+        requires_freezing=requires_freezing,
+        is_dangerous=is_dangerous,
         plans=plans,
     )

--- a/views/policies.py
+++ b/views/policies.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from database import query_db, execute_db
+import json
+
+bp = Blueprint('policies', __name__, url_prefix='/policies')
+
+@bp.route('/')
+def list_policies():
+    rows = query_db("SELECT * FROM Policy")
+    return render_template('policies.html', rows=rows)
+
+@bp.route('/new', methods=['GET', 'POST'])
+def new_policy():
+    if request.method == 'POST':
+        execute_db(
+            "INSERT INTO Policy (description, conditions, action, active) VALUES (?,?,?,?)",
+            [
+                request.form.get('description'),
+                request.form.get('conditions_json'),
+                request.form.get('action_json'),
+                1 if request.form.get('active') else 0,
+            ],
+        )
+        return redirect(url_for('policies.list_policies'))
+    return render_template('policy_form.html', policy=None)
+
+@bp.route('/edit/<int:id>', methods=['GET', 'POST'])
+def edit_policy(id):
+    pol = query_db("SELECT * FROM Policy WHERE id=?", [id], one=True)
+    if request.method == 'POST':
+        execute_db(
+            "UPDATE Policy SET description=?, conditions=?, action=?, active=? WHERE id=?",
+            [
+                request.form.get('description'),
+                request.form.get('conditions_json'),
+                request.form.get('action_json'),
+                1 if request.form.get('active') else 0,
+                id,
+            ],
+        )
+        return redirect(url_for('policies.list_policies'))
+    return render_template('policy_form.html', policy=pol)
+
+@bp.route('/delete/<int:id>', methods=['POST'])
+def delete_policy(id):
+    execute_db("DELETE FROM Policy WHERE id=?", [id])
+    return redirect(url_for('policies.list_policies'))


### PR DESCRIPTION
## Summary
- create Policy table and CRUD pages
- integrate policies into plan recommendation
- extend plan form with shipment info fields
- show policies in navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a2ed2e3a48328b1264f3c840e8a7b