### PR TITLE
Add policy priority and route filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from views import (
     tariffs_bp,
     plan_bp,
     api_bp,
+    policies_bp,
 )
 
 app = Flask(__name__)
@@ -27,6 +28,7 @@ app.register_blueprint(schedules_bp)
 app.register_blueprint(tariffs_bp)
 app.register_blueprint(plan_bp)
 app.register_blueprint(api_bp)
+app.register_blueprint(policies_bp)
 
 if __name__ == '__main__':
     with app.app_context():

--- a/database.py
+++ b/database.py
@@ -92,6 +92,15 @@ CREATE TABLE IF NOT EXISTS Tariff (
     cost REAL,
     FOREIGN KEY (route_id) REFERENCES Route(id)
 );
+
+CREATE TABLE IF NOT EXISTS Policy (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    description TEXT,
+    conditions TEXT,
+    action TEXT,
+    active BOOLEAN,
+    priority INTEGER
+);
 '''
 
 def get_db():
@@ -109,6 +118,11 @@ def close_connection(exception):
 def init_db():
     db = get_db()
     db.executescript(SCHEMA)
+    # ensure new columns exist when schema evolves
+    cur = db.execute("PRAGMA table_info(Policy)")
+    cols = [row[1] for row in cur.fetchall()]
+    if 'priority' not in cols:
+        db.execute("ALTER TABLE Policy ADD COLUMN priority INTEGER DEFAULT 0")
     db.commit()
 
 def query_all(table):

--- a/plan_utils.py
+++ b/plan_utils.py
@@ -1,22 +1,76 @@
 from datetime import datetime, timedelta
 from database import query_db
+import json
 
 
-def find_plans(origin_id, dest_id):
+def load_policies():
+    return query_db("SELECT * FROM Policy WHERE active=1 ORDER BY priority ASC")
+
+
+def evaluate_conditions(conds, facts):
+    ops = {
+        '=': lambda a, b: a == b,
+        '!=': lambda a, b: a != b,
+        '>': lambda a, b: float(a) > float(b),
+        '<': lambda a, b: float(a) < float(b),
+    }
+    result = None
+    prev_conn = 'AND'
+    for c in conds:
+        val = facts.get(c.get('field'))
+        op = ops.get(c.get('op', '='))
+        if op is None:
+            continue
+        res = op(val, type(val)(c.get('value')) if isinstance(val, (int, float)) else c.get('value'))
+        if result is None:
+            result = res
+        else:
+            if prev_conn == 'AND':
+                result = result and res
+            else:
+                result = result or res
+        prev_conn = c.get('connector', 'AND')
+    return result if result is not None else True
+
+
+def route_allowed(route, shipment, policies):
+    facts = {**shipment, **route}
+    for p in policies:
+        try:
+            conds = json.loads(p['conditions']) if p['conditions'] else []
+            if evaluate_conditions(conds, facts):
+                act = json.loads(p['action']) if p['action'] else {}
+                if 'allow_route_ids' in act and route['id'] not in act['allow_route_ids']:
+                    return False
+                if 'block_route_ids' in act and route['id'] in act['block_route_ids']:
+                    return False
+                if 'allow_modes' in act and route.get('transport_mode') not in act['allow_modes']:
+                    return False
+                if 'route_freezing' in act and route.get('supports_freezing') != act['route_freezing']:
+                    return False
+                if 'route_dangerous' in act and route.get('supports_dangerous_goods') != act['route_dangerous']:
+                    return False
+        except Exception:
+            continue
+    return True
+
+def find_plans(origin_id, dest_id, shipment=None):
     """주어진 출발지와 도착지 사이의 가능한 모든 경로를 찾는다."""
 
     # 모든 Route 정보를 조회하여 그래프 형태로 변환
     routes = query_db(
-        "SELECT r.id, r.origin_id, o.name as origin_name, r.destination_id, d.name as destination_name, r.base_cost, r.lead_time "
+        "SELECT r.id, r.origin_id, o.name as origin_name, r.destination_id, d.name as destination_name, r.base_cost, r.lead_time, r.transport_mode, r.supports_freezing, r.supports_dangerous_goods "
         "FROM Route r "
         "LEFT JOIN Location o ON r.origin_id=o.id "
         "LEFT JOIN Location d ON r.destination_id=d.id"
     )
+    policies = load_policies()
 
     # 인접 리스트 형태의 그래프 생성
     adj = {}
     for r in routes:
-        adj.setdefault(r['origin_id'], []).append(r)
+        if shipment is None or route_allowed(r, shipment, policies):
+            adj.setdefault(r['origin_id'], []).append(r)
 
     plans = []
 
@@ -59,9 +113,9 @@ def get_tariff_cost(route_id, date_str):
     return info['cost'] if info else None
 
 
-def recommend_plans(origin_id, dest_id, start_date, end_date):
+def recommend_plans(origin_id, dest_id, start_date, end_date, shipment=None):
     """모든 경로에 대해 비용과 시작일을 계산하여 추천"""
-    plans = find_plans(origin_id, dest_id)
+    plans = find_plans(origin_id, dest_id, shipment)
     start_dt = datetime.strptime(start_date, '%Y-%m-%d').date()
     end_dt = datetime.strptime(end_date, '%Y-%m-%d').date()
     for plan in plans:

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
         <li><a href="{{ url_for('carriers.list_carriers') }}">Carriers</a></li>
         <li><a href="{{ url_for('schedules.list_schedules') }}">Schedules</a></li>
         <li><a href="{{ url_for('tariffs.list_tariffs') }}">Tariff</a></li>
+        <li><a href="{{ url_for('policies.list_policies') }}">Policies</a></li>
         <li><a href="{{ url_for('plan.plan') }}">Plan</a></li>
     </ul>
 </nav>

--- a/templates/plan.html
+++ b/templates/plan.html
@@ -22,9 +22,16 @@
         <select name="dest_id" id="dest_id"></select>
         도착일 <input type="date" name="end_date" value="{{ end_date }}">
     </div>
+    <div>
+        Weight <input type="number" step="0.01" name="weight" value="{{ weight if weight is not none else '' }}">
+        Requires Freezing <input type="checkbox" name="requires_freezing" value="1" {% if requires_freezing %}checked{% endif %}>
+        Dangerous Goods <input type="checkbox" name="is_dangerous" value="1" {% if is_dangerous %}checked{% endif %}>
+    </div>
     <button type="submit">Plan 추천</button>
 </form>
-{% if plans %}
+{% if plans is not none %}
+    {% if plans %}
+    <p>Available routes after policy: {{ plans|length }}</p>
     {% for plan in plans %}
         <h3>Plan {{ loop.index }} - Routes: {{ plan.routes|length }}, Recommended Start: {{ plan.recommended_start }}, Cost Sum: {{ plan.total_cost }}, Lead Time Sum: {{ plan.total_lead_time }}</h3>
         <table>
@@ -44,6 +51,9 @@
             {% endfor %}
         </table>
     {% endfor %}
+    {% else %}
+    <p>조건에 만족하는 경로가 없습니다.</p>
+    {% endif %}
 {% endif %}
 <div id="tariff-tooltip" style="position:absolute;display:none;border:1px solid #ccc;background:#fff;padding:4px;font-size:0.9em;"></div>
 <script>

--- a/templates/policies.html
+++ b/templates/policies.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Policies</h1>
+<a href="{{ url_for('policies.new_policy') }}">Create</a>
+<table>
+    <tr><th>ID</th><th>Description</th><th>Priority</th><th>Active</th><th>Actions</th></tr>
+    {% for p in rows %}
+    <tr>
+        <td>{{ p.id }}</td>
+        <td>{{ p.description }}</td>
+        <td>{{ p.priority }}</td>
+        <td>{{ 'Y' if p.active else 'N' }}</td>
+        <td>
+            <a href="{{ url_for('policies.edit_policy', id=p.id) }}">Edit</a>
+            <form class="inline" method="post" action="{{ url_for('policies.delete_policy', id=p.id) }}">
+                <button type="submit">Delete</button>
+            </form>
+            <form class="inline" method="post" action="{{ url_for('policies.move_policy', id=p.id, direction='up') }}">
+                <button type="submit">▲</button>
+            </form>
+            <form class="inline" method="post" action="{{ url_for('policies.move_policy', id=p.id, direction='down') }}">
+                <button type="submit">▼</button>
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/policy_form.html
+++ b/templates/policy_form.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ 'Edit' if policy else 'New' }} Policy</h1>
+<form method="post" id="policy-form">
+    Description <input type="text" name="description" value="{{ policy.description if policy else '' }}"><br>
+    Active <input type="checkbox" name="active" value="1" {% if policy and policy.active %}checked{% endif %}><br>
+    Priority <input type="number" name="priority" value="{{ policy.priority if policy else '' }}"><br>
+    <h3>Conditions</h3>
+    <table id="conds"></table>
+    <button type="button" onclick="addCond()">Add Condition</button>
+    <input type="hidden" name="conditions_json" id="conditions_json">
+    <h3>Action</h3>
+    Allow Route IDs <input type="text" id="allow_routes" value=""><br>
+    Block Route IDs <input type="text" id="block_routes" value=""><br>
+    Allow Modes <input type="text" id="allow_modes" value=""><br>
+    Route Freezing <select id="route_freezing"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select><br>
+    Route Dangerous <select id="route_dangerous"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select><br>
+    <input type="hidden" name="action_json" id="action_json">
+    <button type="submit">Save</button>
+</form>
+<script>
+const fields = ['requires_freezing','is_dangerous','weight'];
+function addCond(field='',op='=',value='',connector='AND'){
+    const table=document.getElementById('conds');
+    const row=document.createElement('tr');
+    row.innerHTML=`<td><select class="field">${fields.map(f=>`<option value="${f}" ${f==field?'selected':''}>${f}</option>`).join('')}</select></td>`+
+                  `<td><select class="op"><option>=</option><option>!=</option><option>></option><option><</option></select></td>`+
+                  `<td><input class="value" value="${value}"></td>`+
+                  `<td><select class="conn"><option value="AND" ${connector=='AND'?'selected':''}>AND</option><option value="OR" ${connector=='OR'?'selected':''}>OR</option></select></td>`;
+    row.querySelector('.op').value=op;
+    table.appendChild(row);
+}
+function gather(){
+    const conds=[];
+    document.querySelectorAll('#conds tr').forEach(tr=>{
+        conds.push({
+            field:tr.querySelector('.field').value,
+            op:tr.querySelector('.op').value,
+            value:tr.querySelector('.value').value,
+            connector:tr.querySelector('.conn').value
+        });
+    });
+    document.getElementById('conditions_json').value=JSON.stringify(conds);
+    const action={};
+    const allow=document.getElementById('allow_routes').value.trim();
+    if(allow) action.allow_route_ids=allow.split(',').map(s=>parseInt(s.trim())).filter(n=>!isNaN(n));
+    const block=document.getElementById('block_routes').value.trim();
+    if(block) action.block_route_ids=block.split(',').map(s=>parseInt(s.trim())).filter(n=>!isNaN(n));
+    const modes=document.getElementById('allow_modes').value.trim();
+    if(modes) action.allow_modes=modes.split(',').map(s=>s.trim()).filter(s=>s);
+    const rf=document.getElementById('route_freezing').value;
+    if(rf!=='') action.route_freezing=parseInt(rf);
+    const rd=document.getElementById('route_dangerous').value;
+    if(rd!=='') action.route_dangerous=parseInt(rd);
+    document.getElementById('action_json').value=JSON.stringify(action);
+}
+document.getElementById('policy-form').addEventListener('submit',gather);
+{% if policy %}
+const pc = {{ policy.conditions|tojson }};
+try{const conds=JSON.parse(pc);conds.forEach(c=>addCond(c.field,c.op,c.value,c.connector));}catch(e){}
+try{
+    const ac=JSON.parse({{ policy.action|tojson }});
+    if(ac.allow_route_ids) document.getElementById('allow_routes').value=ac.allow_route_ids.join(',');
+    if(ac.block_route_ids) document.getElementById('block_routes').value=ac.block_route_ids.join(',');
+    if(ac.allow_modes) document.getElementById('allow_modes').value=ac.allow_modes.join(',');
+    if(ac.route_freezing!==undefined) document.getElementById('route_freezing').value=String(ac.route_freezing);
+    if(ac.route_dangerous!==undefined) document.getElementById('route_dangerous').value=String(ac.route_dangerous);
+}catch(e){}
+{% else %}
+addCond();
+{% endif %}
+</script>
+{% endblock %}

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -5,6 +5,7 @@ from .schedules import bp as schedules_bp
 from .tariffs import bp as tariffs_bp
 from .plan_view import bp as plan_bp
 from .api import bp as api_bp
+from .policies import bp as policies_bp
 
 __all__ = [
     'locations_bp',
@@ -14,4 +15,5 @@ __all__ = [
     'tariffs_bp',
     'plan_bp',
     'api_bp',
+    'policies_bp',
 ]

--- a/views/plan_view.py
+++ b/views/plan_view.py
@@ -10,6 +10,7 @@ def plan():
     locations = query_db("SELECT id, name, type FROM Location")
     types = sorted({l['type'] for l in locations})
     origin_type = dest_type = origin_id = dest_id = start_date = end_date = None
+    weight = requires_freezing = is_dangerous = None
     plans = None
     if request.method == 'POST':
         origin_type = request.form.get('origin_type')
@@ -18,7 +19,15 @@ def plan():
         dest_id = int(request.form.get('dest_id'))
         start_date = request.form.get('start_date')
         end_date = request.form.get('end_date')
-        plans = recommend_plans(origin_id, dest_id, start_date, end_date)
+        weight = float(request.form.get('weight') or 0)
+        requires_freezing = 1 if request.form.get('requires_freezing') else 0
+        is_dangerous = 1 if request.form.get('is_dangerous') else 0
+        shipment = {
+            'weight': weight,
+            'requires_freezing': requires_freezing,
+            'is_dangerous': is_dangerous,
+        }
+        plans = recommend_plans(origin_id, dest_id, start_date, end_date, shipment)
     return render_template(
         'plan.html',
         types=types,
@@ -29,5 +38,8 @@ def plan():
         dest_id=dest_id,
         start_date=start_date,
         end_date=end_date,
+        weight=weight,
+        requires_freezing=requires_freezing,
+        is_dangerous=is_dangerous,
         plans=plans,
     )

--- a/views/policies.py
+++ b/views/policies.py
@@ -1,0 +1,65 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from database import query_db, execute_db
+import json
+
+bp = Blueprint('policies', __name__, url_prefix='/policies')
+
+@bp.route('/')
+def list_policies():
+    rows = query_db("SELECT * FROM Policy ORDER BY priority ASC")
+    return render_template('policies.html', rows=rows)
+
+@bp.route('/new', methods=['GET', 'POST'])
+def new_policy():
+    if request.method == 'POST':
+        max_p = query_db("SELECT MAX(priority) as m FROM Policy", one=True)['m'] or 0
+        prio = request.form.get('priority')
+        prio = int(prio) if prio not in (None, '') else int(max_p) + 1
+        execute_db(
+            "INSERT INTO Policy (description, conditions, action, active, priority) VALUES (?,?,?,?,?)",
+            [
+                request.form.get('description'),
+                request.form.get('conditions_json'),
+                request.form.get('action_json'),
+                1 if request.form.get('active') else 0,
+                prio,
+            ],
+        )
+        return redirect(url_for('policies.list_policies'))
+    return render_template('policy_form.html', policy=None)
+
+@bp.route('/edit/<int:id>', methods=['GET', 'POST'])
+def edit_policy(id):
+    pol = query_db("SELECT * FROM Policy WHERE id=?", [id], one=True)
+    if request.method == 'POST':
+        execute_db(
+            "UPDATE Policy SET description=?, conditions=?, action=?, active=?, priority=? WHERE id=?",
+            [
+                request.form.get('description'),
+                request.form.get('conditions_json'),
+                request.form.get('action_json'),
+                1 if request.form.get('active') else 0,
+                int(request.form.get('priority') or 0),
+                id,
+            ],
+        )
+        return redirect(url_for('policies.list_policies'))
+    return render_template('policy_form.html', policy=pol)
+
+@bp.route('/delete/<int:id>', methods=['POST'])
+def delete_policy(id):
+    execute_db("DELETE FROM Policy WHERE id=?", [id])
+    return redirect(url_for('policies.list_policies'))
+
+@bp.route('/move/<int:id>/<string:direction>', methods=['POST'])
+def move_policy(id, direction):
+    pol = query_db("SELECT id, priority FROM Policy WHERE id=?", [id], one=True)
+    if not pol:
+        return redirect(url_for('policies.list_policies'))
+    delta = -1 if direction == 'up' else 1
+    new_pri = pol['priority'] + delta
+    other = query_db("SELECT id FROM Policy WHERE priority=?", [new_pri], one=True)
+    if other:
+        execute_db("UPDATE Policy SET priority=? WHERE id=?", [pol['priority'], other['id']])
+    execute_db("UPDATE Policy SET priority=? WHERE id=?", [new_pri, id])
+    return redirect(url_for('policies.list_policies'))


### PR DESCRIPTION
## Summary
- extend Policy table with `priority`
- add form fields and logic to filter routes by freezing or dangerous support
- allow adjusting policy priority and moving policies up/down
- show message when no routes satisfy policies
- add migration step to add `priority` column if missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install flask`
- `python app.py` *(server started after creating db directory)*


------
https://chatgpt.com/codex/tasks/task_e_684a2ed2e3a48328b1264f3c840e8a7b