### PR TITLE
Add freezing and dangerous columns in plan results

### DIFF
--- a/templates/plan.html
+++ b/templates/plan.html
@@ -39,7 +39,7 @@
         <h3>Plan {{ loop.index }} - Routes: {{ plan.routes|length }}, Recommended Start: {{ plan.recommended_start }}, Cost Sum: {{ plan.total_cost }}, Lead Time Sum: {{ plan.total_lead_time }}</h3>
         <table>
             <tr>
-                <th>#</th><th>Route ID</th><th>Origin</th><th>Destination</th><th>Tariff ID</th><th>Cost</th><th>Lead Time</th>
+                <th>#</th><th>Route ID</th><th>Origin</th><th>Destination</th><th>Tariff ID</th><th>Cost</th><th>Lead Time</th><th>Freezing</th><th>Dangerous</th>
             </tr>
             {% for r in plan.routes %}
             <tr>
@@ -50,6 +50,8 @@
                 <td><span class="tariff" data-id="{{ r['tariff_id'] }}">{{ r['tariff_id'] }}</span></td>
                 <td>{{ r['tariff_cost'] }}</td>
                 <td>{{ r['lead_time'] }}</td>
+                <td>{{ r['supports_freezing'] }}</td>
+                <td>{{ r['supports_dangerous_goods'] }}</td>
             </tr>
             {% endfor %}
         </table>


### PR DESCRIPTION
## Summary
- show new Freezing and Dangerous columns on plan results page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a3a6566bc8328904712f9ebb8bb21