### PR TITLE
Allow Flask app access from external hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ pip install -r requirements.txt
 python app.py
 ```
 
-애플리케이션은 `db/onai_route.db` 파일을 사용합니다.
+The server now listens on all network interfaces (0.0.0.0) so you can
+access it from other machines as long as the port is open. The
+application uses the `db/onai_route.db` file for its database.
 
 ## Tariff table
 

--- a/app.py
+++ b/app.py
@@ -33,4 +33,6 @@ app.register_blueprint(policies_bp)
 if __name__ == '__main__':
     with app.app_context():
         init_db()
-    app.run(debug=True)
+    # Listen on all network interfaces so the app is reachable from
+    # external hosts as well as localhost
+    app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
## Summary
- expose server on `0.0.0.0` so it's reachable over a public IP
- document listening behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be1675a608328acc5be874cdbf36d